### PR TITLE
Add ImpersonateSelf syscall

### DIFF
--- a/syscallex/advapi32_windows.go
+++ b/syscallex/advapi32_windows.go
@@ -42,6 +42,7 @@ var (
 
 	procCreateProcessWithLogonW = modadvapi32.NewProc("CreateProcessWithLogonW")
 	procLogonUserW              = modadvapi32.NewProc("LogonUserW")
+	procImpersonateSelf         = modadvapi32.NewProc("ImpersonateSelf")
 	procImpersonateLoggedOnUser = modadvapi32.NewProc("ImpersonateLoggedOnUser")
 	procRevertToSelf            = modadvapi32.NewProc("RevertToSelf")
 	procLookupAccountNameW      = modadvapi32.NewProc("LookupAccountNameW")
@@ -118,6 +119,23 @@ func LogonUser(
 		uintptr(logonType),
 		uintptr(logonProvider),
 		uintptr(unsafe.Pointer(outToken)),
+	)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = e1
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func ImpersonateSelf(impersonationLevel int) (err error) {
+	r1, _, e1 := syscall.Syscall(
+		procImpersonateSelf.Addr(),
+		1,
+		uintptr(impersonationLevel),
+		0, 0,
 	)
 	if r1 == 0 {
 		if e1 != 0 {


### PR DESCRIPTION
This pull request add `ImpersonateSelf` syscall: https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-impersonateself

This syscall is used in conjunction with others to refer to the current running user. For example:

```go
// This is the new function. Without this call, OpenThreadToken will return an error on current thread
ImpersonateSelf(syscallex.SecurityImpersonation)

defer func() {
	syscallex.RevertToSelf()
}()

var impersonationToken syscall.Token
currentThread := syscallex.GetCurrentThread()
err := syscallex.OpenThreadToken(
	currentThread,
	syscall.TOKEN_ALL_ACCESS,
	1,
	&impersonationToken,
)
if err != nil {
	// handle error
}

permissionGranted, err := winox.UserHasPermission(impersonationToken, winox.RightsRead|winox.RightsWrite, path)
```